### PR TITLE
Add Env param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 result
 result-*
 
+# Test lockfile
+tests/flake.lock
+
 # Crush agent state
 .crush/
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ Provide read-write or read-only access to directories.
 })
 ```
 
+### Set Environment Variables
+
+Set environment variables inside the jail.
+
+```nix
+(jailed-agents.lib.${system}.makeJailedPi {
+  env = {
+    EDITOR = "${pkgs.neovim}/bin/nvim";
+    VISUAL = "${pkgs.neovim}/bin/nvim";
+  };
+})
+```
+
 ### Create a Custom Agent
 
 If an agent is not pre-configured, you can easily create a jail for it using `makeJailedAgent`.
@@ -224,6 +237,7 @@ makeJailed<AgentName> {
   extraPkgs ? [],
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
+  env ? {},
   baseJailOptions ? commonJailOptions,
   basePackages ? commonPkgs
 }
@@ -239,6 +253,7 @@ makeJailedAgent {
   extraPkgs ? [],
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
+  env ? {},
   baseJailOptions ? commonJailOptions,
   basePackages ? commonPkgs
 }
@@ -250,6 +265,7 @@ makeJailedAgent {
 - **`extraPkgs`**: A list of additional packages to include in the sandbox.
 - **`extraReadwriteDirs`**: A list of directories to mount with read-write access.
 - **`extraReadonlyDirs`**: A list of directories to mount with read-only access.
+- **`env`**: An attribute set of environment variables to set inside the jail (e.g. `{ EDITOR = "nvim"; }`).
 - **`baseJailOptions`**: Overrides the default set of jail options.
 - **`basePackages`**: Overrides the default set of base packages.
 

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -69,6 +70,7 @@
               ++ (map (p: readonly (noescape p)) extraReadonlyDirs)
               ++ [ (add-pkg-deps basePackages) ]
               ++ [ (add-pkg-deps extraPkgs) ]
+              ++ (pkgs.lib.mapAttrsToList set-env env)
             )
           );
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -93,6 +94,7 @@
               extraReadonlyDirs
               baseJailOptions
               basePackages
+              env
               ;
             configPaths = [
               "~/.config/crush"
@@ -107,6 +109,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -119,6 +122,7 @@
               extraReadonlyDirs
               baseJailOptions
               basePackages
+              env
               ;
             configPaths = [
               "~/.config/opencode"
@@ -134,6 +138,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -146,6 +151,7 @@
               extraReadonlyDirs
               baseJailOptions
               basePackages
+              env
               ;
             configPaths = [
               "~/.gemini"
@@ -159,6 +165,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -171,6 +178,7 @@
               extraReadonlyDirs
               baseJailOptions
               basePackages
+              env
               ;
             configPaths = [
               "~/.pi"
@@ -184,6 +192,7 @@
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
+            env ? { },
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -196,6 +205,7 @@
               extraReadonlyDirs
               baseJailOptions
               basePackages
+              env
               ;
             configPaths = [
               "~/.claude"

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs.jailed-agents.url = "path:..";
+
+  outputs =
+    { jailed-agents, nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+    in
+    {
+      packages.${system} = {
+        default = jailed-agents.lib.${system}.makeJailedAgent {
+          name = "env-test";
+          pkg = pkgs.bashInteractive;
+          configPaths = [ ];
+          env = {
+            MY_TEST_VAR = "hello";
+            ANOTHER_VAR = "world";
+          };
+        };
+      };
+    };
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Agents to build and smoke-test
+packages=(
+  jailed-crush
+  jailed-opencode
+  jailed-gemini-cli
+  jailed-claude-code
+  jailed-pi
+)
+
+pass=0
+fail=0
+
+# --- Build and smoke-test each agent ---
+for package in "${packages[@]}"; do
+  echo "----------------------------------------"
+  echo "Building and testing $package..."
+
+  if ! nix build ".#$package"; then
+    echo -e "\e[31mERROR: Failed to build $package.\e[0m"
+    ((fail++)) || true
+    continue
+  fi
+
+  echo "Build successful. Testing the binary..."
+
+  if ./result/bin/"$package" --help; then
+    echo -e "\e[32mSUCCESS: $package built and tested successfully.\e[0m"
+    ((pass++)) || true
+  else
+    echo -e "\e[31mERROR: Test for $package failed.\e[0m"
+    ((fail++)) || true
+  fi
+done
+
+# --- Test env parameter propagation ---
+echo "----------------------------------------"
+echo "Testing env parameter propagation..."
+
+if ! nix build "./tests"; then
+  echo -e "\e[31mERROR: Failed to build env-test.\e[0m"
+  ((fail++)) || true
+else
+  output=$(./result/bin/env-test -c 'echo "$MY_TEST_VAR $ANOTHER_VAR"')
+  if [ "$output" = "hello world" ]; then
+    echo -e "\e[32mSUCCESS: env vars correctly set in jail\e[0m"
+    ((pass++)) || true
+  else
+    echo -e "\e[31mERROR: expected 'hello world', got '$output'\e[0m"
+    ((fail++)) || true
+  fi
+fi
+
+# --- Summary ---
+echo "----------------------------------------"
+echo -e "Results: \e[32m$pass passed\e[0m, \e[31m$fail failed\e[0m"
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "All packages built and tested successfully!"


### PR DESCRIPTION
Adds an env parameter to makeJailedAgent and all pre-configured builders (makeJailedCrush, makeJailedOpencode, makeJailedGeminiCli, makeJailedPi, makeJailedClaudeCode), allowing users to set environment
 variables inside the sandbox.

 ### Usage

 ```nix
   jailed-agents.lib.${system}.makeJailedPi {
     env = {
       EDITOR = "${pkgs.neovim}/bin/nvim";
       VISUAL = "${pkgs.neovim}/bin/nvim";
     };
   }
 ```

 ### Changes

 - Add env attribute set parameter (default { }) to all builder functions
 - Consume via jail-nix's set-env combinator — no-op when empty
 - Update README with usage example and API docs
 - Add test suite (tests/test.sh) that builds all agents and verifies env var propagation with a bashInteractive fixture

 ### Breaking changes

 None. env defaults to { }, producing identical behavior for existing callers.