### PR TITLE
feat: add hermes-agent builder and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Run `nix develop`, and the `jailed-opencode` command will be available in your s
 | `claude-code`| `makeJailedClaudeCode` | `jailed-claude-code`|
 | `crush`      | `makeJailedCrush`      | `jailed-crush`      |
 | `gemini-cli` | `makeJailedGeminiCli`  | `jailed-gemini-cli` |
+| `hermes-agent` | `makeJailedHermesAgent` | `jailed-hermes-agent` |
 | `opencode`   | `makeJailedOpencode`   | `jailed-opencode`   |
 | `pi`         | `makeJailedPi`         | `jailed-pi`         |
 

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,33 @@
             ];
           };
 
+        makeJailedHermesAgent =
+          {
+            name ? "jailed-hermes-agent",
+            pkg ? llm-agents.packages.${system}.hermes-agent,
+            extraPkgs ? [ ],
+            extraReadwriteDirs ? [ ],
+            extraReadonlyDirs ? [ ],
+            env ? { },
+            baseJailOptions ? commonJailOptions,
+            basePackages ? commonPkgs,
+          }:
+          makeJailedAgent {
+            inherit
+              name
+              pkg
+              extraPkgs
+              extraReadwriteDirs
+              extraReadonlyDirs
+              baseJailOptions
+              basePackages
+              env
+              ;
+            configPaths = [
+              "~/.hermes"
+            ];
+          };
+
         makeJailedPi =
           {
             name ? "jailed-pi",
@@ -222,6 +249,7 @@
           inherit makeJailedClaudeCode;
           inherit makeJailedCrush;
           inherit makeJailedGeminiCli;
+          inherit makeJailedHermesAgent;
           inherit makeJailedOpencode;
           inherit makeJailedPi;
 
@@ -234,6 +262,7 @@
           jailed-claude-code = makeJailedClaudeCode { };
           jailed-crush = makeJailedCrush { };
           jailed-gemini-cli = makeJailedGeminiCli { };
+          jailed-hermes-agent = makeJailedHermesAgent { };
           jailed-opencode = makeJailedOpencode { };
           jailed-pi = makeJailedPi { };
         };

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,6 +8,7 @@ packages=(
   jailed-crush
   jailed-opencode
   jailed-gemini-cli
+  jailed-hermes-agent
   jailed-claude-code
   jailed-pi
 )


### PR DESCRIPTION
Adds Hermes-Agent from llm-agents.nix to flake.nix, readme.md, and tests.sh.

Adds a makeJailedHermesAgent builder function.
Uses jailed-hermes-agent command.
Uses ~/.hermes directory by default.

Test build passed after creating the proper ~/.hermes directory on my system.