### PR TITLE
fix: readwrite mounts take priority over readonly in bwrap args

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
           network
           time-zone
           no-new-session
-          mount-cwd
         ];
 
         makeJailedAgent =
@@ -67,8 +66,9 @@
             with jail.combinators;
             (
               baseJailOptions
-              ++ (map (p: readwrite (noescape p)) (configPaths ++ extraReadwriteDirs))
               ++ (map (p: readonly (noescape p)) extraReadonlyDirs)
+              ++ [ mount-cwd ]
+              ++ (map (p: readwrite (noescape p)) (configPaths ++ extraReadwriteDirs))
               ++ [ (add-pkg-deps basePackages) ]
               ++ [ (add-pkg-deps extraPkgs) ]
               ++ (pkgs.lib.mapAttrsToList set-env env)


### PR DESCRIPTION
Move mount-cwd out of commonJailOptions and place it after readonly binds but before explicit readwrite binds. Reorder extraReadonlyDirs before configPaths/extraReadwriteDirs.

With bubblewrap's later-args-win semantics, this ensures:
- CWD is always readwrite even if a parent is in extraReadonlyDirs
- Explicit readwrite dirs always win over readonly dirs
- Readonly dirs still work for non-overlapping paths