### PR TITLE
Breaking change: remove gemini-cli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Run `nix develop`, and the `jailed-opencode` command will be available in your s
 | ------------ | ---------------------- | ------------------- |
 | `claude-code`| `makeJailedClaudeCode` | `jailed-claude-code`|
 | `crush`      | `makeJailedCrush`      | `jailed-crush`      |
-| `gemini-cli` | `makeJailedGeminiCli`  | `jailed-gemini-cli` |
 | `hermes-agent` | `makeJailedHermesAgent` | `jailed-hermes-agent` |
 | `opencode`   | `makeJailedOpencode`   | `jailed-opencode`   |
 | `pi`         | `makeJailedPi`         | `jailed-pi`         |

--- a/flake.nix
+++ b/flake.nix
@@ -132,33 +132,6 @@
             ];
           };
 
-        makeJailedGeminiCli =
-          {
-            name ? "jailed-gemini-cli",
-            pkg ? llm-agents.packages.${system}.gemini-cli,
-            extraPkgs ? [ ],
-            extraReadwriteDirs ? [ ],
-            extraReadonlyDirs ? [ ],
-            env ? { },
-            baseJailOptions ? commonJailOptions,
-            basePackages ? commonPkgs,
-          }:
-          makeJailedAgent {
-            inherit
-              name
-              pkg
-              extraPkgs
-              extraReadwriteDirs
-              extraReadonlyDirs
-              baseJailOptions
-              basePackages
-              env
-              ;
-            configPaths = [
-              "~/.gemini"
-            ];
-          };
-
         makeJailedHermesAgent =
           {
             name ? "jailed-hermes-agent",
@@ -249,7 +222,6 @@
           inherit makeJailedAgent;
           inherit makeJailedClaudeCode;
           inherit makeJailedCrush;
-          inherit makeJailedGeminiCli;
           inherit makeJailedHermesAgent;
           inherit makeJailedOpencode;
           inherit makeJailedPi;
@@ -262,7 +234,6 @@
         packages = {
           jailed-claude-code = makeJailedClaudeCode { };
           jailed-crush = makeJailedCrush { };
-          jailed-gemini-cli = makeJailedGeminiCli { };
           jailed-hermes-agent = makeJailedHermesAgent { };
           jailed-opencode = makeJailedOpencode { };
           jailed-pi = makeJailedPi { };

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,7 +7,6 @@ cd "$(dirname "$0")/.."
 packages=(
   jailed-crush
   jailed-opencode
-  jailed-gemini-cli
   jailed-hermes-agent
   jailed-claude-code
   jailed-pi


### PR DESCRIPTION
Google has dropped support for the gemini-cli agent. This removes:
- makeJailedGeminiCli builder and its lib export
- jailed-gemini-cli package output
- gemini-cli from README and tests