### PR TITLE
Add Nix daemon access inside the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ makeJailed<AgentName> {
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
   env ? {},
+  enableNix ? false,
+  nixConfigDir ? null,
   baseJailOptions ? commonJailOptions,
   basePackages ? commonPkgs
 }
@@ -254,6 +256,8 @@ makeJailedAgent {
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
   env ? {},
+  enableNix ? false,
+  nixConfigDir ? null,
   baseJailOptions ? commonJailOptions,
   basePackages ? commonPkgs
 }
@@ -266,6 +270,11 @@ makeJailedAgent {
 - **`extraReadwriteDirs`**: A list of directories to mount with read-write access.
 - **`extraReadonlyDirs`**: A list of directories to mount with read-only access.
 - **`env`**: An attribute set of environment variables to set inside the jail (e.g. `{ EDITOR = "nvim"; }`).
+- **`enableNix`**: When `true`, grants the agent access to the host Nix daemon: mounts `/nix` and `/etc/nix/nix.conf` read-only, the daemon socket `/nix/var/nix/daemon-socket` read-write, and adds the `nix` package.
+
+  > **Warning:** `enableNix = true` lets the agent build and execute arbitrary packages from nixpkgs via the Nix daemon, bypassing the sandbox's curated toolset. Only enable it for agents you trust to run arbitrary code.
+
+- **`nixConfigDir`**: Mounts a NixOS/system config directory into the jail so the agent can read (or edit) the declaration. Pass a path string to mount it read-only (e.g. `"/etc/nixos"`), or `{ path = "/etc/nixos"; writable = true; }` to mount it read-write. Defaults to `null` (nothing mounted). Independent of `enableNix`.
 - **`baseJailOptions`**: Overrides the default set of jail options.
 - **`basePackages`**: Overrides the default set of base packages.
 

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,15 @@
           no-new-session
         ];
 
+        nixDaemonAccess = {
+          readwriteDirs = [ "/nix/var/nix/daemon-socket" ];
+          readonlyDirs = [
+            "/nix"
+            "/etc/nix/nix.conf"
+          ];
+          pkgs = [ pkgs.nix ];
+        };
+
         makeJailedAgent =
           {
             name,
@@ -59,18 +68,55 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
+          let
+            # Resolved form of `nixConfigDir`: null, or { path, writable }.
+            resolvedNixConfigDir =
+              if nixConfigDir == null then
+                null
+              else if builtins.isString nixConfigDir then
+                {
+                  path = nixConfigDir;
+                  writable = false;
+                }
+              else if builtins.isAttrs nixConfigDir then
+                if nixConfigDir ? path then
+                  {
+                    inherit (nixConfigDir) path;
+                    writable = nixConfigDir.writable or false;
+                  }
+                else
+                  throw "nixConfigDir attrset requires a 'path' attribute"
+              else
+                throw "nixConfigDir must be null, a path string, or an attrset { path, writable }";
+
+            readonlyDirs =
+              extraReadonlyDirs
+              ++ pkgs.lib.optionals enableNix nixDaemonAccess.readonlyDirs
+              ++ pkgs.lib.optional (
+                resolvedNixConfigDir != null && !resolvedNixConfigDir.writable
+              ) resolvedNixConfigDir.path;
+            readwriteDirs =
+              extraReadwriteDirs
+              ++ pkgs.lib.optionals enableNix nixDaemonAccess.readwriteDirs
+              ++ pkgs.lib.optional (
+                resolvedNixConfigDir != null && resolvedNixConfigDir.writable
+              ) resolvedNixConfigDir.path;
+            extraPackages = extraPkgs ++ pkgs.lib.optionals enableNix nixDaemonAccess.pkgs;
+          in
           jail name pkg (
             with jail.combinators;
             (
               baseJailOptions
-              ++ (map (p: readonly (noescape p)) extraReadonlyDirs)
+              ++ (map (p: readonly (noescape p)) readonlyDirs)
               ++ [ mount-cwd ]
-              ++ (map (p: readwrite (noescape p)) (configPaths ++ extraReadwriteDirs))
+              ++ (map (p: readwrite (noescape p)) (configPaths ++ readwriteDirs))
               ++ [ (add-pkg-deps basePackages) ]
-              ++ [ (add-pkg-deps extraPkgs) ]
+              ++ [ (add-pkg-deps extraPackages) ]
               ++ (pkgs.lib.mapAttrsToList set-env env)
             )
           );
@@ -83,6 +129,8 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -93,6 +141,8 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              enableNix
+              nixConfigDir
               baseJailOptions
               basePackages
               env
@@ -111,6 +161,8 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -121,6 +173,8 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              enableNix
+              nixConfigDir
               baseJailOptions
               basePackages
               env
@@ -140,6 +194,8 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -150,6 +206,8 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              enableNix
+              nixConfigDir
               baseJailOptions
               basePackages
               env
@@ -167,6 +225,8 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -177,6 +237,8 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              enableNix
+              nixConfigDir
               baseJailOptions
               basePackages
               env
@@ -194,6 +256,8 @@
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
             env ? { },
+            enableNix ? false,
+            nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
           }:
@@ -204,6 +268,8 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              enableNix
+              nixConfigDir
               baseJailOptions
               basePackages
               env

--- a/flake.nix
+++ b/flake.nix
@@ -121,10 +121,15 @@
             )
           );
 
-        makeJailedCrush =
+        makePreconfiguredAgent =
           {
-            name ? "jailed-crush",
-            pkg ? llm-agents.packages.${system}.crush,
+            defaultName,
+            defaultPkg,
+            configPaths,
+          }:
+          {
+            name ? defaultName,
+            pkg ? defaultPkg,
             extraPkgs ? [ ],
             extraReadwriteDirs ? [ ],
             extraReadonlyDirs ? [ ],
@@ -141,144 +146,54 @@
               extraPkgs
               extraReadwriteDirs
               extraReadonlyDirs
+              env
               enableNix
               nixConfigDir
               baseJailOptions
               basePackages
-              env
+              configPaths
               ;
-            configPaths = [
-              "~/.config/crush"
-              "~/.local/share/crush"
-            ];
           };
 
-        makeJailedOpencode =
-          {
-            name ? "jailed-opencode",
-            pkg ? llm-agents.packages.${system}.opencode,
-            extraPkgs ? [ ],
-            extraReadwriteDirs ? [ ],
-            extraReadonlyDirs ? [ ],
-            env ? { },
-            enableNix ? false,
-            nixConfigDir ? null,
-            baseJailOptions ? commonJailOptions,
-            basePackages ? commonPkgs,
-          }:
-          makeJailedAgent {
-            inherit
-              name
-              pkg
-              extraPkgs
-              extraReadwriteDirs
-              extraReadonlyDirs
-              enableNix
-              nixConfigDir
-              baseJailOptions
-              basePackages
-              env
-              ;
-            configPaths = [
-              "~/.config/opencode"
-              "~/.local/share/opencode"
-              "~/.local/state/opencode"
-            ];
-          };
+        makeJailedCrush = makePreconfiguredAgent {
+          defaultName = "jailed-crush";
+          defaultPkg = llm-agents.packages.${system}.crush;
+          configPaths = [
+            "~/.config/crush"
+            "~/.local/share/crush"
+          ];
+        };
 
-        makeJailedHermesAgent =
-          {
-            name ? "jailed-hermes-agent",
-            pkg ? llm-agents.packages.${system}.hermes-agent,
-            extraPkgs ? [ ],
-            extraReadwriteDirs ? [ ],
-            extraReadonlyDirs ? [ ],
-            env ? { },
-            enableNix ? false,
-            nixConfigDir ? null,
-            baseJailOptions ? commonJailOptions,
-            basePackages ? commonPkgs,
-          }:
-          makeJailedAgent {
-            inherit
-              name
-              pkg
-              extraPkgs
-              extraReadwriteDirs
-              extraReadonlyDirs
-              enableNix
-              nixConfigDir
-              baseJailOptions
-              basePackages
-              env
-              ;
-            configPaths = [
-              "~/.hermes"
-            ];
-          };
+        makeJailedOpencode = makePreconfiguredAgent {
+          defaultName = "jailed-opencode";
+          defaultPkg = llm-agents.packages.${system}.opencode;
+          configPaths = [
+            "~/.config/opencode"
+            "~/.local/share/opencode"
+            "~/.local/state/opencode"
+          ];
+        };
 
-        makeJailedPi =
-          {
-            name ? "jailed-pi",
-            pkg ? llm-agents.packages.${system}.pi,
-            extraPkgs ? [ ],
-            extraReadwriteDirs ? [ ],
-            extraReadonlyDirs ? [ ],
-            env ? { },
-            enableNix ? false,
-            nixConfigDir ? null,
-            baseJailOptions ? commonJailOptions,
-            basePackages ? commonPkgs,
-          }:
-          makeJailedAgent {
-            inherit
-              name
-              pkg
-              extraPkgs
-              extraReadwriteDirs
-              extraReadonlyDirs
-              enableNix
-              nixConfigDir
-              baseJailOptions
-              basePackages
-              env
-              ;
-            configPaths = [
-              "~/.pi"
-            ];
-          };
+        makeJailedHermesAgent = makePreconfiguredAgent {
+          defaultName = "jailed-hermes-agent";
+          defaultPkg = llm-agents.packages.${system}.hermes-agent;
+          configPaths = [ "~/.hermes" ];
+        };
 
-        makeJailedClaudeCode =
-          {
-            name ? "jailed-claude-code",
-            pkg ? llm-agents.packages.${system}.claude-code,
-            extraPkgs ? [ ],
-            extraReadwriteDirs ? [ ],
-            extraReadonlyDirs ? [ ],
-            env ? { },
-            enableNix ? false,
-            nixConfigDir ? null,
-            baseJailOptions ? commonJailOptions,
-            basePackages ? commonPkgs,
-          }:
-          makeJailedAgent {
-            inherit
-              name
-              pkg
-              extraPkgs
-              extraReadwriteDirs
-              extraReadonlyDirs
-              enableNix
-              nixConfigDir
-              baseJailOptions
-              basePackages
-              env
-              ;
-            configPaths = [
-              "~/.claude"
-              "~/.claude.json"
-            ];
-          };
+        makeJailedPi = makePreconfiguredAgent {
+          defaultName = "jailed-pi";
+          defaultPkg = llm-agents.packages.${system}.pi;
+          configPaths = [ "~/.pi" ];
+        };
+
+        makeJailedClaudeCode = makePreconfiguredAgent {
+          defaultName = "jailed-claude-code";
+          defaultPkg = llm-agents.packages.${system}.claude-code;
+          configPaths = [
+            "~/.claude"
+            "~/.claude.json"
+          ];
+        };
 
       in
       {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -27,6 +27,30 @@
           pkg = pkgs.bashInteractive;
           configPaths = [ ];
         };
+
+        nix-enabled-test = jailed-agents.lib.${system}.makeJailedAgent {
+          name = "nix-enabled-test";
+          pkg = pkgs.bashInteractive;
+          configPaths = [ ];
+          enableNix = true;
+        };
+
+        nixconfig-readonly-test = jailed-agents.lib.${system}.makeJailedAgent {
+          name = "nixconfig-readonly-test";
+          pkg = pkgs.bashInteractive;
+          configPaths = [ ];
+          nixConfigDir = "/tmp/jailed-agents-nixconfig-test";
+        };
+
+        nixconfig-writable-test = jailed-agents.lib.${system}.makeJailedAgent {
+          name = "nixconfig-writable-test";
+          pkg = pkgs.bashInteractive;
+          configPaths = [ ];
+          nixConfigDir = {
+            path = "/tmp/jailed-agents-nixconfig-test";
+            writable = true;
+          };
+        };
       };
     };
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -55,6 +55,80 @@ else
   fi
 fi
 
+# --- Test enableNix (nix binary + daemon mounts) ---
+echo "----------------------------------------"
+echo "Testing enableNix..."
+
+if ! nix build "./tests#nix-enabled-test"; then
+  echo "ERROR: Failed to build nix-enabled-test."
+  ((fail++)) || true
+else
+  if ./result/bin/nix-enabled-test -c 'nix --version' \
+    && ./result/bin/nix-enabled-test -c 'ls /nix/store' \
+    && ./result/bin/nix-enabled-test -c 'ls /nix/var/nix/daemon-socket'; then
+    echo "SUCCESS: nix binary and daemon mounts present in jail"
+    ((pass++)) || true
+  else
+    echo "ERROR: nix binary or daemon mounts not accessible in jail"
+    ((fail++)) || true
+  fi
+
+  if ./result/bin/nix-enabled-test -c 'nix store info >/dev/null 2>&1'; then
+    echo "SUCCESS: nix daemon reachable from inside the jail"
+    ((pass++)) || true
+  else
+    echo "ERROR: nix daemon not reachable from inside the jail"
+    ((fail++)) || true
+  fi
+fi
+
+# --- Test nixConfigDir readonly vs writable ---
+echo "----------------------------------------"
+echo "Testing nixConfigDir readonly/writable..."
+
+NIXCFG_DIR="/tmp/jailed-agents-nixconfig-test"
+rm -rf "$NIXCFG_DIR"
+mkdir -p "$NIXCFG_DIR"
+echo "sentinel" > "$NIXCFG_DIR/configuration.nix"
+
+# readonly: read works, write fails
+if ! nix build "./tests#nixconfig-readonly-test"; then
+  echo "ERROR: Failed to build nixconfig-readonly-test."
+  ((fail++)) || true
+else
+  ro_read=$(./result/bin/nixconfig-readonly-test -c 'cat /tmp/jailed-agents-nixconfig-test/configuration.nix' 2>/dev/null || true)
+  ro_write_failed=0
+  ./result/bin/nixconfig-readonly-test -c 'echo mutated > /tmp/jailed-agents-nixconfig-test/configuration.nix' 2>/dev/null || ro_write_failed=1
+  if [ "$ro_read" = "sentinel" ] && [ "$ro_write_failed" -eq 1 ]; then
+    echo "SUCCESS: nixConfigDir readonly mounts read-only"
+    ((pass++)) || true
+  else
+    echo "ERROR: nixConfigDir readonly misbehaved (read='$ro_read', write_failed=$ro_write_failed)"
+    ((fail++)) || true
+  fi
+fi
+
+# writable: read and write both succeed
+if ! nix build "./tests#nixconfig-writable-test"; then
+  echo "ERROR: Failed to build nixconfig-writable-test."
+  ((fail++)) || true
+else
+  echo "sentinel" > "$NIXCFG_DIR/configuration.nix"
+  rw_read=$(./result/bin/nixconfig-writable-test -c 'cat /tmp/jailed-agents-nixconfig-test/configuration.nix' 2>/dev/null || true)
+  rw_write_ok=1
+  ./result/bin/nixconfig-writable-test -c 'echo mutated > /tmp/jailed-agents-nixconfig-test/configuration.nix' 2>/dev/null || rw_write_ok=0
+  rw_after=$(./result/bin/nixconfig-writable-test -c 'cat /tmp/jailed-agents-nixconfig-test/configuration.nix' 2>/dev/null || true)
+  if [ "$rw_read" = "sentinel" ] && [ "$rw_write_ok" -eq 1 ] && [ "$rw_after" = "mutated" ]; then
+    echo "SUCCESS: nixConfigDir writable mounts read-write"
+    ((pass++)) || true
+  else
+    echo "ERROR: nixConfigDir writable misbehaved (read='$rw_read', write_ok=$rw_write_ok, after='$rw_after')"
+    ((fail++)) || true
+  fi
+fi
+
+rm -rf "$NIXCFG_DIR"
+
 # --- Summary ---
 echo "----------------------------------------"
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
   Closes #92.

   Adds opt-in access to the host Nix daemon from inside a jailed agent, so an agent
   can build/run nix packages via the daemon without otherwise weakening the
   sandbox.

   ## New parameters

   Added to `makeJailedAgent` and all five `makeJailed*` wrappers:

   - **`enableNix`** *(default `false`)* — mounts `/nix` and `/etc/nix/nix.conf`
     read-only, the daemon socket `/nix/var/nix/daemon-socket` read-write, and adds
     the `nix` package. The agent can then talk to the host daemon (`nix build`,
     `nix run`, …).
   - **`nixConfigDir`** *(default `null`)* — mounts a NixOS/system config declaration
     so the agent can read or edit it. Accepts a path string (read-only) or
     `{ path = "/etc/nixos"; writable = true; }` (read-write). Orthogonal to `enableNix`.

     ```nix
     makeJailedOpencode { enableNix = true; nixConfigDir = "/etc/nixos"; }