### PR TITLE
Add option fwdEnv to forward environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ Set environment variables inside the jail.
 })
 ```
 
+### Forward Environment Variables
+
+Set environment variables inside the jail by copying them from the outside.
+```nix
+(jailed-agents.lib.${system}.makeJailedPi {
+  fwdEnv = [ "PKG_CONFIG_PATH" ];
+})
+```
+
+Take care to not forward anything secrets. Trying to forward nonexistent variables will result in an error.
+
 ### Create a Custom Agent
 
 If an agent is not pre-configured, you can easily create a jail for it using `makeJailedAgent`.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Set environment variables inside the jail by copying them from the outside.
 })
 ```
 
-Take care to not forward anything secrets. Trying to forward nonexistent variables will result in an error.
+Take care to not forward any secrets. Trying to forward nonexistent variables will result in an error.
 
 ### Create a Custom Agent
 
@@ -261,6 +261,7 @@ makeJailed<AgentName> {
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
   env ? {},
+  fwdEnv ? [],
   enableNix ? false,
   nixConfigDir ? null,
   baseJailOptions ? commonJailOptions,
@@ -279,6 +280,7 @@ makeJailedAgent {
   extraReadwriteDirs ? [],
   extraReadonlyDirs ? [],
   env ? {},
+  fwdEnv ? [],
   enableNix ? false,
   nixConfigDir ? null,
   baseJailOptions ? commonJailOptions,
@@ -293,6 +295,7 @@ makeJailedAgent {
 - **`extraReadwriteDirs`**: A list of directories to mount with read-write access.
 - **`extraReadonlyDirs`**: A list of directories to mount with read-only access.
 - **`env`**: An attribute set of environment variables to set inside the jail (e.g. `{ EDITOR = "nvim"; }`).
+- **`fwdEnv`**: A list of environment variables to forward from the host shell into the jail (e.g. `[ "PKG_CONFIG_PATH" ]`). Errors at startup if a variable is unset.
 - **`enableNix`**: When `true`, grants the agent access to the host Nix daemon: mounts `/nix` and `/etc/nix/nix.conf` read-only, the daemon socket `/nix/var/nix/daemon-socket` read-write, and adds the `nix` package.
 
   > **Warning:** `enableNix = true` lets the agent build and execute arbitrary packages from nixpkgs via the Nix daemon, bypassing the sandbox's curated toolset. Only enable it for agents you trust to run arbitrary code.

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
             extraReadonlyDirs ? [ ],
             env ? { },
             enableNix ? false,
-	    fwdEnv ? [ ],
+            fwdEnv ? [ ],
             nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
@@ -123,7 +123,7 @@
               ++ (map (p: readwrite (noescape p)) (configPaths ++ readwriteDirs))
               ++ [ (add-pkg-deps basePackages) ]
               ++ [ (add-pkg-deps extraPackages) ]
-	      ++ (map (e: fwd-env e) fwdEnv)
+              ++ (map fwd-env fwdEnv)
               ++ (pkgs.lib.mapAttrsToList set-env env)
             )
           );
@@ -142,7 +142,7 @@
             extraReadonlyDirs ? [ ],
             env ? { },
             enableNix ? false,
-	    fwdEnv ? [ ],
+            fwdEnv ? [ ],
             nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
@@ -156,7 +156,7 @@
               extraReadonlyDirs
               env
               enableNix
-	      fwdEnv
+              fwdEnv
               nixConfigDir
               baseJailOptions
               basePackages

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
             extraReadonlyDirs ? [ ],
             env ? { },
             enableNix ? false,
+	    fwdEnv ? [ ],
             nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
@@ -122,6 +123,7 @@
               ++ (map (p: readwrite (noescape p)) (configPaths ++ readwriteDirs))
               ++ [ (add-pkg-deps basePackages) ]
               ++ [ (add-pkg-deps extraPackages) ]
+	      ++ (map (e: fwd-env e) fwdEnv)
               ++ (pkgs.lib.mapAttrsToList set-env env)
             )
           );
@@ -140,6 +142,7 @@
             extraReadonlyDirs ? [ ],
             env ? { },
             enableNix ? false,
+	    fwdEnv ? [ ],
             nixConfigDir ? null,
             baseJailOptions ? commonJailOptions,
             basePackages ? commonPkgs,
@@ -153,6 +156,7 @@
               extraReadonlyDirs
               env
               enableNix
+	      fwdEnv
               nixConfigDir
               baseJailOptions
               basePackages


### PR DESCRIPTION
I've added this because in my development shell I needed to pass along `PKG_CONFIG_PATH`, which is a major hassle just with static `env`. Maybe this could be useful to someone else as well.